### PR TITLE
No 'grados' y cambio ligero en reporte

### DIFF
--- a/salvitobot/writer.py
+++ b/salvitobot/writer.py
@@ -12,8 +12,8 @@ class Writer(object):
 
     """
     def __init__(self):
-        self.template = "Un _tremor_ de _magnitude_level_ magnitud de _magnitude_integer_ " \
-                        "grados _magnitude_type_ se produjo el _date_local_str_ por la _time_of_day_ a " \
+        self.template = "Un _tremor_ de magnitud _magnitude_integer_ _magnitude_type_" \
+                        "(_magnitude_level_) se produjo el _date_local_str_ por la _time_of_day_ a " \
                         "_epicenter_, reportó el Servicio Geológico de EE.UU. \n\n" \
                         "El _tremor_ se registró a las _time_ de la _time_of_day_, " \
                         "hora local, a una profundidad de " \
@@ -43,11 +43,11 @@ class Writer(object):
                 tremor = 'temblor'
 
             if item['magnitude'] >= 7:
-                magnitude_level = 'gran'
+                magnitude_level = 'fuerte'
             elif 4 < item['magnitude'] < 7:
-                magnitude_level = 'mediana'
+                magnitude_level = 'moderado'
             else:
-                magnitude_level = 'escasa'
+                magnitude_level = 'leve'
 
             magnitude_integer = str(item['magnitude'])
             date_local = item['datetime_local']

--- a/salvitobot/writer.py
+++ b/salvitobot/writer.py
@@ -12,7 +12,7 @@ class Writer(object):
 
     """
     def __init__(self):
-        self.template = "Un _tremor_ de magnitud _magnitude_integer_ _magnitude_type_" \
+        self.template = "Un _tremor_ de magnitud _magnitude_integer_ _magnitude_type_ " \
                         "(_magnitude_level_) se produjo el _date_local_str_ por la _time_of_day_ a " \
                         "_epicenter_, reportó el Servicio Geológico de EE.UU. \n\n" \
                         "El _tremor_ se registró a las _time_ de la _time_of_day_, " \
@@ -87,8 +87,8 @@ class Writer(object):
             text = re.sub('_time_', time, text)
             text = re.sub('_depth_', depth, text)
 
-            title = tremor.capitalize() + ' de ' + magnitude_integer
-            title += ' grados ' + str(item['magnitude_type']).capitalize()
+            title = tremor.capitalize() + ' de magnitud' + magnitude_integer
+            title += ' ' +str(item['magnitude_type']).capitalize()
             title += ' se registró a ' + epicenter
 
             story = {


### PR DESCRIPTION
Para una mejor praxis, se remueve el término "grados" y se hace una propuesta de modificación en el template del reporte.
